### PR TITLE
Patch to make cpan-outdated work with currently selected perl

### DIFF
--- a/bin/cpan-outdated
+++ b/bin/cpan-outdated
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use warnings;
 use Getopt::Long;


### PR DESCRIPTION
I think cpan-outdated should function with the currently selected perl, as used with perlbrew. If you don't use perlbrew, this change makes no difference.

I think it's much more useful to check with the currently active version of perl, rather than the system installed version.
