### PR TITLE
xargs(1) is optional for cpanm

### DIFF
--- a/bin/cpan-outdated
+++ b/bin/cpan-outdated
@@ -341,6 +341,6 @@ This library is free software; you can redistribute it and/or modify it under th
 
 L<CPAN>
 
-L<App::cpanm>
+L<App::cpanminus>
 
 =cut


### PR DESCRIPTION
`cpan-outdated | cpanm` is enough, and `cpan-outdated -p | cpanm` is also useful.
