### PR TITLE
Use local index copy

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'IO::Zlib';
 requires 'LWP';
 requires 'Module::CoreList';
 requires 'Module::Metadata', '1.000007';
+requires 'URI';
 requires 'local::lib', '1.006008';
 requires 'version';
 

--- a/script/cpan-outdated
+++ b/script/cpan-outdated
@@ -176,8 +176,7 @@ sub get_index {
     } else {
 	# If the file is empty we do not trust its timestamp (as it may just
 	# have been created if a temp file) so we can't use $ua->mirror
-        require HTTP::Request;
-        $response = $ua->request(HTTP::Request->new(GET => $url), "$fname");
+        $response = $ua->get($url, ':content_file' => "$fname");
     }
     if (my $died = $response->header('X-Died')) {
         die "Cannot get_index $url to $fname: $died";

--- a/script/cpan-outdated
+++ b/script/cpan-outdated
@@ -61,10 +61,10 @@ sub main {
     # warn join("\n", @libpath);
 
     if (   !defined($index_file)
-	|| ! -e $index_file || -z $index_file
-	|| !$index_url->isa('URI::file')) {
+        || ! -e $index_file || -z $index_file
+        || !$index_url->isa('URI::file')) {
 
-	$index_file = get_index($index_url, $index_file)
+        $index_file = get_index($index_url, $index_file)
     }
 
     my $fh = zopen($index_file) or die "cannot open $index_file";
@@ -187,8 +187,8 @@ sub get_index {
     if (-s "$fname") {
         $response = $ua->mirror($url, "$fname"); # Explicitely stringify
     } else {
-	# If the file is empty we do not trust its timestamp (as it may just
-	# have been created if a temp file) so we can't use $ua->mirror
+        # If the file is empty we do not trust its timestamp (as it may just
+        # have been created if a temp file) so we can't use $ua->mirror
         $response = $ua->get($url, ':content_file' => "$fname");
     }
     if (my $died = $response->header('X-Died')) {

--- a/script/cpan-outdated
+++ b/script/cpan-outdated
@@ -52,7 +52,7 @@ sub main {
     my @libpath = make_inc($local_lib, $self_contained);
     # warn join("\n", @libpath);
 
-    my $index_file = getstore($index_url);
+    my $index_file = get_index($index_url);
 
     my $fh = zopen($index_file) or die "cannot open $index_file";
     # skip header part
@@ -161,7 +161,7 @@ sub which {
 }
 
 # Return the $fname (a generated File::Temp object if not provided)
-sub getstore {
+sub get_index {
     my ($url, $fname) = @_;
     require LWP::UserAgent;
     my $ua = LWP::UserAgent->new(
@@ -180,10 +180,10 @@ sub getstore {
         $response = $ua->request(HTTP::Request->new(GET => $url), "$fname");
     }
     if (my $died = $response->header('X-Died')) {
-        die "Cannot getstore $url to $fname: $died";
+        die "Cannot get_index $url to $fname: $died";
     # 304 = "Not Modified" (returned if we are mirroring)
     } elsif (! $response->is_success && $response->code != 304) {
-        die "Cannot getstore $url to $fname: " . $response->status_line;
+        die "Cannot get_index $url to $fname: " . $response->status_line;
     }
     #print "$fname ", $response->status_line, "\n";
     # Return the filename

--- a/script/cpan-outdated
+++ b/script/cpan-outdated
@@ -26,6 +26,7 @@ Getopt::Long::GetOptions(
     'h|help'          => \my $help,
     'verbose'         => \my $verbose,
     'm|mirror=s'      => \$mirror,
+    'index'           => \$index_file,
     'p|print-package' => \my $print_package,
     'I=s'             => sub { die "this option was deprecated" },
     'l|local-lib=s'   => \$local_lib,
@@ -44,6 +45,7 @@ $mirror =~ s:/$::;
 my $index_url = "${mirror}/modules/02packages.details.txt.gz";
 $index_url = URI->new($index_url);
 if ($index_url->isa('URI::file')) {
+    die '--index is incompatible with a file:// mirror' if defined $index_file;
     $index_file = $index_url->file
 }
 

--- a/script/cpan-outdated
+++ b/script/cpan-outdated
@@ -11,6 +11,7 @@ use IO::Zlib;
 use CPAN::DistnameInfo;
 use Module::CoreList ();
 use Module::Metadata;
+use URI;
 use constant WIN32 => $^O eq 'MSWin32';
 
 our $VERSION = "0.28";
@@ -19,6 +20,7 @@ my $mirror = 'http://www.cpan.org/';
 my $quote = WIN32 ? q/"/ : q/'/;
 my $local_lib;
 my $self_contained = 0;
+my $index_file;
 Getopt::Long::Configure("bundling");
 Getopt::Long::GetOptions(
     'h|help'          => \my $help,
@@ -40,6 +42,10 @@ pod2usage() if $help;
 
 $mirror =~ s:/$::;
 my $index_url = "${mirror}/modules/02packages.details.txt.gz";
+$index_url = URI->new($index_url);
+if ($index_url->isa('URI::file')) {
+    $index_file = $index_url->file
+}
 
 my $core_modules = $Module::CoreList::version{$]};
 
@@ -52,7 +58,12 @@ sub main {
     my @libpath = make_inc($local_lib, $self_contained);
     # warn join("\n", @libpath);
 
-    my $index_file = get_index($index_url);
+    if (   !defined($index_file)
+	|| ! -e $index_file || -z $index_file
+	|| !$index_url->isa('URI::file')) {
+
+	$index_file = get_index($index_url, $index_file)
+    }
 
     my $fh = zopen($index_file) or die "cannot open $index_file";
     # skip header part

--- a/script/cpan-outdated
+++ b/script/cpan-outdated
@@ -7,7 +7,6 @@ use File::Temp;
 use File::Spec;
 use Config;
 use version;
-use LWP::Simple ();
 use IO::Zlib;
 use CPAN::DistnameInfo;
 use Module::CoreList ();
@@ -53,10 +52,9 @@ sub main {
     my @libpath = make_inc($local_lib, $self_contained);
     # warn join("\n", @libpath);
 
-    my $tmpfile = File::Temp->new(UNLINK => 1, SUFFIX => '.gz');
-    getstore($index_url, $tmpfile->filename);
+    my $index_file = getstore($index_url);
 
-    my $fh = zopen($tmpfile) or die "cannot open $tmpfile";
+    my $fh = zopen($index_file) or die "cannot open $index_file";
     # skip header part
     while (my $line = <$fh>) {
         last if $line eq "\n";
@@ -162,25 +160,39 @@ sub which {
     return;
 }
 
+# Return the $fname (a generated File::Temp object if not provided)
 sub getstore {
     my ($url, $fname) = @_;
+    require LWP::UserAgent;
     my $ua = LWP::UserAgent->new(
         parse_head => 0,
     );
     $ua->env_proxy();
-    my $request = HTTP::Request->new(GET => $url);
-    my $response = $ua->request($request, $fname);
+    $fname = File::Temp->new(UNLINK => 1, SUFFIX => '.gz') unless defined $fname;
+    my $response;
+    # If the file is not empty, use it as a local cached copy
+    if (-s "$fname") {
+        $response = $ua->mirror($url, "$fname"); # Explicitely stringify
+    } else {
+	# If the file is empty we do not trust its timestamp (as it may just
+	# have been created if a temp file) so we can't use $ua->mirror
+        require HTTP::Request;
+        $response = $ua->request(HTTP::Request->new(GET => $url), "$fname");
+    }
     if (my $died = $response->header('X-Died')) {
         die "Cannot getstore $url to $fname: $died";
-    } elsif ($response->code == 200) {
-        return 1;
-    } else {
+    # 304 = "Not Modified" (returned if we are mirroring)
+    } elsif (! $response->is_success && $response->code != 304) {
         die "Cannot getstore $url to $fname: " . $response->status_line;
     }
+    #print "$fname ", $response->status_line, "\n";
+    # Return the filename
+    $fname
 }
 
 sub zopen {
-    IO::Zlib->new($_[0], "rb");
+    # Explicitely stringify the filename as it may be a File::Temp object
+    IO::Zlib->new("$_[0]", "rb");
 }
 
 sub make_inc {


### PR DESCRIPTION
In the current implementation, the index is always downloaded from the mirror. This takes a long time and is painful. Especially when you run `cpan-outdated` multiple times successively.

This branch refactor the fetching code to enable the following features:
- use any mirror protocol, not just HTTP or file (for example ftp, sftp...)
- do not copy the index file if the mirror is `file://`, but instead directly use the file
- allow to use directly a local copy of the index given with a new `--index` option. If the mirror is not `file://`, that copy will be checked against the mirror and updated if necessary using HTTP caching rules (`If-Modified-Since` with the local timestamp).