### PR TITLE
Limit the modules to check

### DIFF
--- a/script/cpan-outdated
+++ b/script/cpan-outdated
@@ -63,6 +63,14 @@ sub modules_to_check {
     ExtUtils::Installed->new(skip_cwd => 1, inc_override => \@inc)->modules;
 }
 
+sub installed_version_for {
+    my($pkg, $inc) = @_;
+
+    local $SIG{__WARN__} = sub {};
+    my $meta = Module::Metadata->new_from_module($pkg, inc => $inc);
+    $meta ? $meta->version($pkg) : undef;
+}
+
 sub main {
     my @inc = make_inc($local_lib, $self_contained);
 
@@ -99,48 +107,19 @@ sub main {
         next if $exclude_core && exists $core_modules->{$pkg};
 
         next if $dist =~ m{/perl-[0-9._]+\.tar\.(gz|bz2)$};
-        (my $file = $pkg) =~ s!::!/!g;
-        $file = "${file}.pm";
-      SCAN_INC: for my $dir (@inc) {
-            my $path = "$dir/$file";
-            next SCAN_INC unless -f $path;
 
-            # ignore old distribution.
-            #   This is a heuristic approach. It is not a strict.
-            #   If you want a strict check, cpan-outdated looks 02packages.details.txt.gz twice.
-            #   It is too slow.
-            #
-            #   But, 02packages.details.txt.gz is sorted.
-            #   Submodules are listed after main module most of the time.
-            #   This strategy works well for now.
-            # ref https://github.com/tokuhirom/cpan-outdated/issues#issue/4
-            my $info = CPAN::DistnameInfo->new($dist);
-            if (my $latest = $dist_latest_version{$info->dist}) {
-                # $info->version < $latest
-                if (compare_version($info->version, $latest)) {
-                    # warn "SKIP old distribution ($pkg): $dist < ", $latest, "\n";
-                    next LINES; # skip old version
-                }
-            }
-            $dist_latest_version{$info->dist} = $info->version;
+        my $inst_version = installed_version_for($pkg, \@inc)
+            or next;
 
-            my $meta = do {
-                local $SIG{__WARN__} = sub {};
-                Module::Metadata->new_from_file($path);
-            };
-            my $inst_version = $meta->version($pkg);
-            next unless defined $inst_version;
-            if (compare_version($inst_version, $version)) {
-                $seen{$dist}++;
-                if ($verbose) {
-                    printf "%-30s %-7s %-7s %s\n", $pkg, $inst_version, $version, $dist;
-                } elsif ($print_package) {
-                    print "$pkg\n";
-                } else {
-                    print "$dist\n";
-                }
+        if (compare_version($inst_version, $version)) {
+            $seen{$dist}++;
+            if ($verbose) {
+                printf "%-30s %-7s %-7s %s\n", $pkg, $inst_version, $version, $dist;
+            } elsif ($print_package) {
+                print "$pkg\n";
+            } else {
+                print "$dist\n";
             }
-            last SCAN_INC;
         }
     }
 }

--- a/script/cpan-outdated
+++ b/script/cpan-outdated
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
+use ExtUtils::Installed;
 use Getopt::Long;
 use Pod::Usage;
 use File::Temp;
@@ -56,9 +57,14 @@ unless ($ENV{HARNESS_ACTIVE}) {
     exit;
 }
 
+sub modules_to_check {
+    my @inc = @_;
+    # TODO: if you want to filter the target modules, you can change them here.
+    ExtUtils::Installed->new(skip_cwd => 1, inc_override => \@inc)->modules;
+}
+
 sub main {
-    my @libpath = make_inc($local_lib, $self_contained);
-    # warn join("\n", @libpath);
+    my @inc = make_inc($local_lib, $self_contained);
 
     if (   !defined($index_file)
         || ! -e $index_file || -z $index_file
@@ -66,6 +72,8 @@ sub main {
 
         $index_file = get_index($index_url, $index_file)
     }
+
+    my %installed = map { $_ => 1 } modules_to_check(@inc);
 
     my $fh = zopen($index_file) or die "cannot open $index_file";
     # skip header part
@@ -77,7 +85,9 @@ sub main {
     my %dist_latest_version;
     LINES: while (my $line = <$fh>) {
         my ($pkg, $version, $dist) = split /\s+/, $line;
+        next unless $installed{$pkg};
         next if $version eq 'undef';
+
         # The note below about the latest version heuristics applies here too
         next if $seen{$dist};
 
@@ -91,7 +101,7 @@ sub main {
         next if $dist =~ m{/perl-[0-9._]+\.tar\.(gz|bz2)$};
         (my $file = $pkg) =~ s!::!/!g;
         $file = "${file}.pm";
-        SCAN_INC: for my $dir (@libpath) {
+      SCAN_INC: for my $dir (@inc) {
             my $path = "$dir/$file";
             next SCAN_INC unless -f $path;
 


### PR DESCRIPTION
as commented in #27:

here's a rewritten, much simplified code that does the same thing. Instead of checking all of the modules in 02packages, this new code gets the list of installed modules using ExtUtils::Installed, and then only check those modules. As requested in #24, this can be a basis for the further work to limit the module names to filter in the future (not implemented yet).

Also eliminated a lot of heuristics to avoid submodules being pulled from older distributions, because EU::I gives you the list of "primary" module names, and we probably don't need to worry about those leftovers anymore.

As commented in the commit message, there might be a case where you can't catch when a submodule is split into a separate distribution, but then ideally, an old distribution that contained that submodule would pull them in as it is upgraded.
